### PR TITLE
README: add travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JuttleViz
 
+[![Build Status](https://travis-ci.org/juttle/juttle-viz.svg)](https://travis-ci.org/juttle/juttle-viz)
+
 JuttleViz is the chart library used by [Outrigger](http://www.github.com/juttle/outrigger) to render the visual outputs of [Juttle](http://www.github.com/juttle/juttle) programs.
 
 Check out the [documentation](http://juttle.github.io/juttle-viz) to see what charts are available and how to use them to visualize data.


### PR DESCRIPTION
Add the travis badge to the README which had the side-effect of kicking off a build and making travis go green.
