### PR TITLE
missing charts tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,9 +89,9 @@ gulp.task('test-coverage', ['instrument'], function() {
         thresholds: {
             global: {
                 statements: 55,
-                branches: 43,
+                branches: 44,
                 functions: 50,
-                lines: 55
+                lines: 56
             }
         }
     }));

--- a/src/lib/charts/bar-chart.js
+++ b/src/lib/charts/bar-chart.js
@@ -171,7 +171,8 @@ BarChart.prototype._addBars = function() {
         tooltip : this.options.tooltip,
         margin : this.options.margin,
         color : this.options.color,
-        negativeColor : this.options.negativeColor
+        negativeColor : this.options.negativeColor,
+        duration: this.options.duration
     };
 
     this.bars = new Bars(barsArea.node(), baropts);

--- a/src/lib/generators/bars.js
+++ b/src/lib/generators/bars.js
@@ -47,7 +47,7 @@ Bars.prototype.set_value = function(val) {
     this.tooltipOptions.valueField = this.tooltipOptions.valueField || val;
 };
 
-Bars.prototype.draw = function(data,options) {
+Bars.prototype.draw = function(data, options) {
     var self = this;
 
     return new Promise(function(resolve, reject) {
@@ -70,8 +70,11 @@ Bars.prototype.draw = function(data,options) {
             .attr('class', 'bar');
 
         var barsexit = bars.exit()
-            .each(function(d) { self.removeTooltip(d); } )
-            .transition().duration(duration);
+            .each(function(d) { self.removeTooltip(d); } );
+        
+        if (duration !== 0) { 
+            barsexit = barsexit.transition().duration(duration);
+        }
 
         var update = bars
             .each(function(d) { self.updateTooltip(d); } )
@@ -91,8 +94,11 @@ Bars.prototype.draw = function(data,options) {
                         self.options.negativeColor;
                 }
 
-            })
-            .transition().duration(self.options.duration);
+            });
+
+        if (duration !== 0) { 
+            update = update.transition().duration(duration);
+        }
 
         var transitionCount = update.size() + barsexit.size();
 
@@ -114,10 +120,13 @@ Bars.prototype.draw = function(data,options) {
                 .attr('y', self.value_scale(0))
                 .attr('height', 0)
                 .attr('opacity', 0)
-                .remove()
-                .each( 'end', function(d) {
+                .remove();
+
+            if (duration !== 0) { 
+                barsexit.each( 'end', function(d) {
                     transitionFinished();
                 });
+            }
 
             update
                 .attr('x', function(d) {
@@ -142,10 +151,13 @@ Bars.prototype.draw = function(data,options) {
                     else {
                         return self.value_scale(d[self.value_field]) - self.value_scale(0);
                     }
-                } )
-                .each( 'end', function() {
+                });
+
+            if (duration !== 0) { 
+                update.each( 'end', function() {
                     transitionFinished();
                 });
+            }
         }
         else {
             barsenter
@@ -161,10 +173,13 @@ Bars.prototype.draw = function(data,options) {
                 .attr('x', self.value_scale(0))
                 .attr('width', 0)
                 .attr('opacity', 0)
-                .remove()
-                .each( 'end', function(d) {
+                .remove();
+
+            if (duration !== 0) { 
+                barsexit.each( 'end', function(d) {
                     transitionFinished();
                 });
+            }
 
             update
                 .attr('x', function(d) {
@@ -189,14 +204,21 @@ Bars.prototype.draw = function(data,options) {
                         return self.value_scale(0) - self.value_scale(d[self.value_field]);
                     }
                 } )
-                .attr('height', self.category_scale.rangeBand())
-                .each( 'end', function() {
+                .attr('height', self.category_scale.rangeBand());
+
+            if (duration !== 0) { 
+                update.each( 'end', function() {
                     transitionFinished();
                 });
+            }
         }
 
-        if (transitionCount === 0) {
-            transitionFinished();
+        if (duration !== 0) { 
+            if (transitionCount === 0) {
+                transitionFinished();
+            }
+        } else { 
+            resolve();
         }
     });
 };

--- a/src/lib/generators/points.js
+++ b/src/lib/generators/points.js
@@ -90,14 +90,16 @@ Points.prototype.draw = function(data) {
 
 Points.prototype.redraw = function() {
     var self = this;
-
-    this._circles
-        .transition()
-        .duration(this._attributes.duration)
-        .ease('linear')
-        .attr('cx', function(d) { return self._getX(d); })
-        .attr('cy', function(d) { return self._getY(d); })
-        .attr('fill-opacity', this._opacity);
+    
+    if (this._attributes.duration !== 0) {
+        this._circles
+            .transition()
+            .duration(this._attributes.duration)
+            .ease('linear')
+            .attr('cx', function(d) { return self._getX(d); })
+            .attr('cy', function(d) { return self._getY(d); })
+            .attr('fill-opacity', this._opacity);
+    }
 
 };
 
@@ -120,9 +122,11 @@ Points.prototype._onMouseLeave = function(d) {
 // stops animation of data-points
 Points.prototype._stopAnimation = function() {
     // stop all animation
-    this._points.selectAll('.point')
-        .transition()
-        .duration(0);
+    if (this._attributes.duration !== 0) { 
+        this._points.selectAll('.point')
+            .transition()
+            .duration(0);
+    }
 };
 
 

--- a/test/lib/charts/bar-chart.spec.js
+++ b/test/lib/charts/bar-chart.spec.js
@@ -1,86 +1,90 @@
+var _ = require('underscore');
+var expect = require('chai').expect;
 require('chai').should();
 
 describe('Bar Chart', function () {
     var BarChart = require('../../../src/lib/charts/bar-chart');
 
-    describe('Constructor', function () {
-        beforeEach(function (done) {
-            this.el = document.createElement('div');
-            this.chart = new BarChart(this.el,{
-                yScales : {
-                    primary : {
-                        scaling : 'linear'
-                    }
-                },
-                xScale : {
-                },
-                display : {
-                    orientation : 'vertical'
+    it('can draw a series with linear y scale scaling', function (done) {
+        var el = document.createElement('div');
+        var chart = new BarChart(el, {
+            categoryField : 'category',
+            valueField : 'value',
+            yScales : {
+                primary : {
+                    scaling : 'linear'
                 }
-            });
-            done();
+            },
+            xScale : {
+            },
+            duration: 0
         });
 
-        afterEach(function (done) {
-            delete this.el;
-            delete this.chart;
-            done();
-        });
+        chart.resize(100,100);
 
-        it('should initialise the chart correctly', function (done) {
-            this.chart.should.have.property.options;
-            this.chart.should.have.property.svg;
-            this.chart.should.have.property.el;
-            this.chart.should.have.property.axesArea;
-            this.chart.should.have.property.barsArea;
-            this.chart.should.have.property.dataTarget;
-            this.chart.should.have.property.bars;
-            this.chart.should.have.property.xAxis;
-            this.chart.should.have.property.yAxis;
+        var data = [
+            { category: 'north', value: 1 },
+            { category: 'south', value: 2 },
+            { category: 'east', value: 3 },
+            { category: 'west', value: 4 },
+            { category: 'up', value: 5 },
+            { category: 'down', value: 6 }
+        ];
+
+        chart.dataTarget.push(data)
+        .then(function() {
+            var rects = el.querySelectorAll('rect.bar');
+            rects.should.be.truthy;
+            rects.length.should.equal(6);
             done();
         });
     });
 
-    describe('Drawing', function() {
-        beforeEach(function (done) {
-            this.el = document.createElement('div');
-            this.chart = new BarChart(this.el, {
-                categoryField : 'category',
-                valueField : 'value',
-                yScales : {
-                    primary : {
-                        scaling : 'linear'
-                    }
-                },
-                xScale : {
-                },
-                display : {
-                    orientation : 'vertical'
+    it('can draw a series with log y scale scaling', function (done) {
+        var el = document.createElement('div');
+        var chart = new BarChart(el, {
+            categoryField : 'category',
+            valueField : 'value',
+            yScales : {
+                primary : {
+                    scaling : 'log'
                 }
-            });
-            this.chart.resize(100,100).then(function() {
-                done();
-            });
+            },
+            xScale : {
+            },
+            duration: 0
         });
-        afterEach(function (done) {
-            delete this.el;
-            delete this.chart;
+
+        chart.resize(100,100);
+
+        var data = [
+            { category: 'north', value: 1 },
+            { category: 'south', value: 2 },
+            { category: 'east', value: 3 },
+            { category: 'west', value: 4 },
+            { category: 'up', value: 5 },
+            { category: 'down', value: 6 }
+        ];
+
+        chart.dataTarget.push(data)
+        .then(function() {
+            var rects = el.querySelectorAll('rect.bar');
+            rects.should.be.truthy;
+            rects.length.should.equal(6);
             done();
         });
-        it('should draw a series', function (done) {
-            var data = [ { category: 'north', value: 1 },
-                         { category: 'south', value: 2 },
-                         { category: 'east', value: 3 },
-                         { category: 'west', value: 4 },
-                         { category: 'up', value: 5 },
-                         { category: 'down', value: 6 } ];
-            var self = this;
-            this.chart.dataTarget.push(data).then(function() {
-                var rects = self.el.querySelectorAll('rect.bar');
-                rects.should.be.truthy;
-                rects.length.should.equal(6);
-                done();
+    });
+
+    it('fails when given an invalid yScales.primary.scaling value', function () {
+        expect(function() {
+            var el = document.createElement('div');
+            new new BarChart(el, {
+                yScales : {
+                    primary : {
+                        scaling : 'bogus'
+                    }
+                }
             });
-        });
+        }).to.throw(/Unsupported scale type: bogus/);
     });
 });

--- a/test/lib/charts/pie-chart.spec.js
+++ b/test/lib/charts/pie-chart.spec.js
@@ -1,0 +1,54 @@
+require('chai').should();
+
+describe('Pie Chart', function () {
+    var PieChart = require('../../../src/lib/charts/pie-chart');
+
+    it('can draw a pie with 4 equal slices', function (done) {
+        var el = document.createElement('div');
+        var chart = new PieChart(el, {
+            categoryField : 'category',
+            valueField : 'value',
+            display : {
+                orientation : 'vertical'
+            },
+            duration: 0
+        });
+
+        chart.resize(100, 100);
+
+        var data = [{ category: 'north', value: 1 },
+                    { category: 'south', value: 1 },
+                    { category: 'east', value: 1 },
+                    { category: 'west', value: 1 } ];
+        chart.dataTarget.push(data)
+        .then(function() {
+            var slices = el.querySelectorAll('path.slice');
+            slices.should.be.truthy;
+            slices.length.should.equal(4);
+            done();
+        });
+    });
+
+    it('can draw a pie with no slices', function (done) {
+        var el = document.createElement('div');
+        var chart = new PieChart(el, {
+            categoryField : 'category',
+            valueField : 'value',
+            display : {
+                orientation : 'vertical'
+            },
+            duration: 0
+        });
+
+        chart.resize(100, 100);
+        var data = [];
+        chart.dataTarget.push(data)
+        .then(function() {
+            var slices = el.querySelectorAll('path.slice');
+            slices.should.be.truthy;
+            slices.length.should.equal(0);
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
fixes #21 

Will use this PR to increase test coverage of all of the charts under `lib/charts` and also unify the way the charts are tested and the way their tests are written. This includes:
- [x] bar-chart
- [x] pie-chart
- [ ] scatter-chart
- [ ] table
- [ ] tile
- [ ] time-base
