### PR TITLE
time field: fix which views require time in points and which ones don't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents all notable changes to juttle-viz. The release numbering uses [semantic versioning](http://semver.org).
 
+## 0.3.1
+
+Released 2016-01-21
+
+### Bug Fixes
+
+- time field: fix which views require time in points and which ones don't [[#32](https://github.com/juttle/juttle-viz/pull/32)]
+
 ## 0.3.0
 
 Released 2016-01-20

--- a/src/views/events.js
+++ b/src/views/events.js
@@ -141,6 +141,16 @@ var EventsView = JuttleView.extend({
         this.target.stream_end();
     },
 
+    _validateTimeField : function(time) {
+        // if in timechart overlay, timeField needs to actually be a Date
+        if (this._targetView) {
+            return _.isDate(time) && !_.isNaN(time.getTime());
+        }
+        else {
+            return true;
+        }
+    },
+
     _handleInvalidTimeField : function() {
         JuttleView.prototype._handleInvalidTimeField.apply(this);
         if (this._targetView) {

--- a/src/views/juttle-view.js
+++ b/src/views/juttle-view.js
@@ -66,7 +66,7 @@ var JuttleView = Base.extend({
             this._receivedData();
         }
 
-        this._validateTimeField(batch);
+        this._validateTimeFieldsInBatch(batch);
 
         if (_.isFunction(this._consume)) {
             this._consume(batch);
@@ -296,17 +296,21 @@ var JuttleView = Base.extend({
         this.runtimeMessages.add(commonRuntimeMessages.WAITING_FOR_DATA);
     },
 
-    _validateTimeField : function(batch) {
+    _validateTimeFieldsInBatch : function(batch) {
         if (this._attributes && this._attributes.timeField) {
             for (var i=0; i<batch.length; i++) {
                 var timeFieldValue = batch[i][this._attributes.timeField];
 
-                if (!(_.isDate(timeFieldValue) && !_.isNaN(timeFieldValue.getTime()))) {
+                if (!this._validateTimeField(timeFieldValue)) {
                     this._handleInvalidTimeField();
                     return;
                 }
             }
         }
+    },
+
+    _validateTimeField : function(time) {
+        return true;
     },
 
     _handleInvalidTimeField : function() {

--- a/src/views/timechart.js
+++ b/src/views/timechart.js
@@ -301,6 +301,10 @@ var TimeChartView = JuttleView.extend({
         this.chart.apply_update();
     },
 
+    _validateTimeField: function(time) {
+        return _.isDate(time) && !_.isNaN(time.getTime());
+    },
+
     _setTimeRangeFrom: function(timeBounds, juttleNow) {
         var from = juttleViewUtils.getExtremeTimeBound(timeBounds, juttleNow, "from");
         if (from) {

--- a/test/views/barchart.spec.js
+++ b/test/views/barchart.spec.js
@@ -279,5 +279,23 @@ describe('Bar Chart Sink View', function () {
                 valueField : 'v'
             });
         });
+
+        it("doesn't complain about timeless points", function() {
+            var chart = new BarChartView({});
+            chart.setDimensions(null, 200, 200);
+
+            chart.consume([
+                {
+                    category: "A",
+                    value: 1
+                },
+                {
+                    category: "B",
+                    value: 1
+                }
+            ]);
+
+            viewTestUtils.verifyNoRuntimeMessages(chart);
+        });
     });
 });

--- a/test/views/events.spec.js
+++ b/test/views/events.spec.js
@@ -1,8 +1,10 @@
 require('chai').should();
 var viewTestUtils = require('./utils/view-test-utils');
 
+var EventsView = require('../../src/views/events');
+var TimeChartView = require('../../src/views/timechart');
+
 describe('Table Sink View', function () {
-    var EventsView = require('../../src/views/events');
 
     describe('invalid params', function() {
         it('unknown top level field', function() {
@@ -33,6 +35,67 @@ describe('Table Sink View', function () {
                     }
                 }
             });
+        });
+    });
+
+    describe('Runtime Messages', function () {
+        it("doesn't complain about timeless points when not in overlay", function() {
+            var chart = new EventsView({});
+            chart.setDimensions(null, 200, 200);
+
+            chart.consume([
+                {
+                    category: "A",
+                    value: 1
+                },
+                {
+                    category: "B",
+                    value: 1
+                }
+            ]);
+
+            viewTestUtils.verifyNoRuntimeMessages(chart);
+        });
+
+        it("complains on timechart about timeless points when overlaying", function() {
+            var timeChart = new TimeChartView({
+                juttleEnv: {
+                    now: new Date()
+                },
+                params: {
+                    id: 1
+                }
+            });
+
+            timeChart.setDimensions(null, 200, 200);
+
+            timeChart.consume([
+                {
+                    time: new Date(),
+                    value: 1
+                }
+            ]);
+
+            var chart = new EventsView({
+                params: {
+                    on: 1
+                }
+            }, [timeChart]);
+
+            chart.setDimensions(null, 200, 200);
+
+            chart.consume([
+                {
+                    category: "A",
+                    value: 1
+                },
+                {
+                    category: "B",
+                    value: 1
+                }
+            ]);
+
+            viewTestUtils.verifyRuntimeMessage(timeChart, 'TIME_FIELD_ERROR');
         });
     });
 });

--- a/test/views/piechart.spec.js
+++ b/test/views/piechart.spec.js
@@ -172,5 +172,24 @@ describe('Pie Sink View', function () {
                 valueField : 'v'
             });
         });
+
+        it("doesn't complain about timeless points", function() {
+            var chart = new PieView({});
+            chart.setDimensions(null, 200, 200);
+
+            chart.consume([
+                {
+                    category: "A",
+                    value: 1
+                },
+                {
+                    category: "B",
+                    value: 1
+                }
+            ]);
+
+            viewTestUtils.verifyNoRuntimeMessages(chart);
+        });
+
     });
 });

--- a/test/views/table.spec.js
+++ b/test/views/table.spec.js
@@ -114,5 +114,23 @@ describe('Table Sink View', function () {
             chart.runtimeMessages.getMessages().at(0).get('code').should.eql('NO_DATA_RECEIVED');
             chart.runtimeMessages.getMessages().length.should.eql(1);
         });
+
+        it("doesn't complain about timeless points", function() {
+            var chart = new TableView({});
+            chart.setDimensions(null, 200, 200);
+
+            chart.consume([
+                {
+                    category: "A",
+                    value: 1
+                },
+                {
+                    category: "B",
+                    value: 1
+                }
+            ]);
+
+            viewTestUtils.verifyNoRuntimeMessages(chart);
+        });
     });
 });

--- a/test/views/text.spec.js
+++ b/test/views/text.spec.js
@@ -310,5 +310,23 @@ describe('TextView Sink View', function () {
 
             verifyTextViewContents(chart, [pt1,pt2], 'raw');
         });
+
+        it("doesn't complain about timeless points", function() {
+            var chart = new TextView({});
+            chart.setDimensions(null, 200, 200);
+
+            chart.consume([
+                {
+                    category: "A",
+                    value: 1
+                },
+                {
+                    category: "B",
+                    value: 1
+                }
+            ]);
+
+            viewTestUtils.verifyNoRuntimeMessages(chart);
+        });
     });
 });

--- a/test/views/tile.spec.js
+++ b/test/views/tile.spec.js
@@ -110,5 +110,23 @@ describe('Tile Sink View', function () {
 
             viewTestUtils.verifyNoRuntimeMessages(chart);
         });
+
+        it("doesn't complain about timeless points", function() {
+            var chart = new TileView({});
+            chart.setDimensions(null, 200, 200);
+
+            chart.consume([
+                {
+                    category: "A",
+                    value: 1
+                },
+                {
+                    category: "B",
+                    value: 1
+                }
+            ]);
+
+            viewTestUtils.verifyNoRuntimeMessages(chart);
+        });
     });
 });


### PR DESCRIPTION
There was some code removed in #25 that related to whether a given view requires time in points or not removed. The result was that all views require time in points which is incorrect.

Bring the code back and add tests to make sure views don't complain about points without time.

Fixes #31.

@rlgomes @mnibecker 
