### PR TITLE
fix eslintrc for test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,7 @@ gulp.task('test', function () {
 
 gulp.task('lint-test', function() {
     return gulp.src([
-        'test/**/*.spec.js'
+        'test/**/*.js'
     ])
     .pipe(eslint())
 	.pipe(eslint.format())

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,23 +1,10 @@
 {
-    "extends": "eslint:recommended",
-    "ecmaFeatures": {
-        "modules": true
-    },
     "env": {
         "browser": true,
         "node": true,
         "es6": true,
         "mocha": true
     },
-    "rules": {
-        "indent": [ 2, 4, { "SwitchCase": 1 } ],
-        "linebreak-style": [ 2, "unix" ],
-        "no-unused-vars": [2, { "args": "none" }],
-        "react/jsx-uses-react": 1,
-        "semi": [ 2, "always" ],
-        "no-console": 2
-    },
-    "parser": "babel-eslint",
     "plugins": [
         "mocha"
     ]

--- a/test/lib/charts/table.spec.js
+++ b/test/lib/charts/table.spec.js
@@ -8,7 +8,7 @@ function verifyHeaders(tableEl, headers) {
     ths.length.should.equal(headers.length);
 
     Array.prototype.forEach.call(ths, function(th, i) {
-        th.innerHTML.should.equal(" " + headers[i] + " " + '<div>'
+        th.innerHTML.should.equal(' ' + headers[i] + ' ' + '<div>'
                                     + headers[i] + '</div>');
     });
 }
@@ -25,13 +25,13 @@ function verifyData(tableEl, headers, data) {
             var dpVal = dp[headers[j]];
 
             if (dpVal === undefined) {
-                td.innerHTML.should.equal("");
+                td.innerHTML.should.equal('');
             }
             else if (_.isDate(dpVal) ) {
                 td.innerHTML.should.equal(timeFormatter(dpVal));
             }
             else {
-                td.innerHTML.should.equal("" + dpVal);
+                td.innerHTML.should.equal('' + dpVal);
             }
             
         });
@@ -100,11 +100,11 @@ describe('Table', function () {
                 it( 'time, name, and value are present in data', function() {
                     var data = [
                         {
-                            someOtherField: "yada",
+                            someOtherField: 'yada',
                             name: 'who',
                             time: new Date(),
                             andAnotherField: 'scoobster',
-                            value: "Winter is coming"
+                            value: 'Winter is coming'
                         }
                     ];
 
@@ -118,7 +118,7 @@ describe('Table', function () {
                 it( 'name is present in data', function() {
                     var data = [
                         {
-                            someOtherField: "yada",
+                            someOtherField: 'yada',
                             name: 'who',
                             andAnotherField: 'scoobster'
                         }
@@ -132,11 +132,11 @@ describe('Table', function () {
                 it('fields not present at first should be added to the right in alpha order', function() {
                     this.table.dataTarget.push([
                         {
-                            someOtherField: "yada",
+                            someOtherField: 'yada',
                             name: 'who',
                             time: new Date(),
                             andAnotherField: 'scoobster',
-                            value: "Winter is coming"
+                            value: 'Winter is coming'
                         }
                     ]);
 

--- a/test/lib/data-targets/adaptive-data-target.spec.js
+++ b/test/lib/data-targets/adaptive-data-target.spec.js
@@ -10,7 +10,7 @@ describe('Adaptive Data Target', function () {
     // var next_time = new Date('2014-09-10T20:00:00Z').getTime();
     
     function assertDatesAreEqual(date1,date2) {
-        assert(date1.getTime() === date2.getTime(), "Expected " + date1 + " to equal " + date2);
+        assert(date1.getTime() === date2.getTime(), 'Expected ' + date1 + ' to equal ' + date2);
     }
     
     function make_points(n) {

--- a/test/lib/data-targets/base-data-target.spec.js
+++ b/test/lib/data-targets/base-data-target.spec.js
@@ -30,7 +30,7 @@ describe('Base Data Target', function () {
                 this.dt.on('debt', this.payDebt, this);
                 this.dt.events.should.have.property('debt');
                 this.dt.events.debt.should.deep.equal([{
-                    token: "0",
+                    token: '0',
                     callback: this.payDebt,
                     context: this
                 }]);
@@ -59,7 +59,7 @@ describe('Base Data Target', function () {
             });
 
             it('should return false if the token could not be found', function () {
-                this.dt.off("10").should.be.false;
+                this.dt.off('10').should.be.false;
             });
         });
         describe('trigger', function () {
@@ -89,8 +89,8 @@ describe('Base Data Target', function () {
                 };
 
                 this.dt.on('attack', function(eventName, args) {
-                    this.city.should.equal("Winterfell");
-                    this.house.should.equal("Stark");
+                    this.city.should.equal('Winterfell');
+                    this.house.should.equal('Stark');
                     done();
                 }, context);
 

--- a/test/lib/generators/area.spec.js
+++ b/test/lib/generators/area.spec.js
@@ -55,7 +55,7 @@ describe('Area generator', function() {
         });
     });
 
-    describe("drawing", function() {
+    describe('drawing', function() {
         beforeEach(function() {
             this.el = document.createElement('svg');
             this.area = new Area(this.el, {

--- a/test/lib/generators/bars.spec.js
+++ b/test/lib/generators/bars.spec.js
@@ -1,6 +1,6 @@
 require('chai').should();
 
-describe("Bars generator", function() {
+describe('Bars generator', function() {
     function createBarElement() {
         var container = document.createElement('div');
         var svg = document.createElement('svg');
@@ -17,7 +17,7 @@ describe("Bars generator", function() {
     var Bars = require('../../../src/lib/generators/bars');
     var d3 = require('d3');
 
-    describe("initialisation", function() {
+    describe('initialisation', function() {
         beforeEach(function () {
             // create a new svg element
             var el = createBarElement();
@@ -56,7 +56,7 @@ describe("Bars generator", function() {
         });
     });
 
-    describe("simple drawing", function() {
+    describe('simple drawing', function() {
         beforeEach(function() {
             this.el = createBarElement();
             this.bars = new Bars(this.el, {

--- a/test/lib/generators/event-markers.spec.js
+++ b/test/lib/generators/event-markers.spec.js
@@ -4,7 +4,7 @@ var EventMarkers = require('../../../src/lib/generators/event-markers');
 var d3 = require('d3');
 var $ = require('jquery');
 
-describe("Event marker generator", function() {
+describe('Event marker generator', function() {
     it('hover correctly turned on and off', function() {
         var el = document.createElement('div');
         var eventMarkersView = new EventMarkers(el, {

--- a/test/lib/generators/line.spec.js
+++ b/test/lib/generators/line.spec.js
@@ -1,10 +1,10 @@
 require('chai').should();
 
-describe("Line generator", function() {
+describe('Line generator', function() {
     var Line = require('../../../src/lib/generators/line');
     var d3 = require('d3');
 
-    describe("initialisation", function() {
+    describe('initialisation', function() {
         beforeEach(function () {
             // create a new svg element
             var el = document.createElement('svg');
@@ -52,7 +52,7 @@ describe("Line generator", function() {
         });
     });
 
-    describe("simple drawing", function() {
+    describe('simple drawing', function() {
         beforeEach(function() {
             this.el = document.createElement('svg');
             this.line = new Line(this.el, {

--- a/test/lib/generators/x-axis.spec.js
+++ b/test/lib/generators/x-axis.spec.js
@@ -2,10 +2,10 @@ var d3 = require('d3');
 
 var sampleScale = d3.scale.linear().domain([0,1]).range(0,800);
 
-describe("X-Axis generator", function() {
+describe('X-Axis generator', function() {
     var xAxisGenerator = require('../../../src/lib/generators/x-axis');
 
-    describe("initialisation", function() {
+    describe('initialisation', function() {
 
         beforeEach(function() {
             var el = document.createElement('svg');
@@ -37,7 +37,7 @@ describe("X-Axis generator", function() {
         });
     });
 
-    describe("simple drawing", function() {
+    describe('simple drawing', function() {
         beforeEach(function() {
             this.el = document.createElement('svg');
             this.xAxis = new xAxisGenerator(this.el);
@@ -99,7 +99,7 @@ describe("X-Axis generator", function() {
 
     });
 
-    describe("orientation", function() {
+    describe('orientation', function() {
         beforeEach(function() {
             this.el = document.createElement('svg');
             this.xAxis = new xAxisGenerator(this.el);

--- a/test/lib/generators/y-axis.spec.js
+++ b/test/lib/generators/y-axis.spec.js
@@ -2,10 +2,10 @@ var d3 = require('d3');
 
 var sampleScale = d3.scale.linear().domain([0,1]).range(0,800);
 
-describe("Y-Axis generator", function() {
+describe('Y-Axis generator', function() {
     var yAxisGenerator = require('../../../src/lib/generators/y-axis');
 
-    describe("initialisation", function() {
+    describe('initialisation', function() {
 
         beforeEach(function() {
             var el = document.createElement('svg');
@@ -37,7 +37,7 @@ describe("Y-Axis generator", function() {
         });
     });
 
-    describe("simple drawing", function() {
+    describe('simple drawing', function() {
         beforeEach(function() {
             this.el = document.createElement('svg');
             this.yAxis = new yAxisGenerator(this.el, {
@@ -85,7 +85,7 @@ describe("Y-Axis generator", function() {
 
     });
 
-    describe("orientation", function() {
+    describe('orientation', function() {
         beforeEach(function() {
             this.el = document.createElement('svg');
             this.yAxis = new yAxisGenerator(this.el);

--- a/test/views/barchart.spec.js
+++ b/test/views/barchart.spec.js
@@ -280,17 +280,17 @@ describe('Bar Chart Sink View', function () {
             });
         });
 
-        it("doesn't complain about timeless points", function() {
+        it('doesn\'t complain about timeless points', function() {
             var chart = new BarChartView({});
             chart.setDimensions(null, 200, 200);
 
             chart.consume([
                 {
-                    category: "A",
+                    category: 'A',
                     value: 1
                 },
                 {
-                    category: "B",
+                    category: 'B',
                     value: 1
                 }
             ]);

--- a/test/views/events.spec.js
+++ b/test/views/events.spec.js
@@ -39,17 +39,17 @@ describe('Table Sink View', function () {
     });
 
     describe('Runtime Messages', function () {
-        it("doesn't complain about timeless points when not in overlay", function() {
+        it('doesn\'t complain about timeless points when not in overlay', function() {
             var chart = new EventsView({});
             chart.setDimensions(null, 200, 200);
 
             chart.consume([
                 {
-                    category: "A",
+                    category: 'A',
                     value: 1
                 },
                 {
-                    category: "B",
+                    category: 'B',
                     value: 1
                 }
             ]);
@@ -57,7 +57,7 @@ describe('Table Sink View', function () {
             viewTestUtils.verifyNoRuntimeMessages(chart);
         });
 
-        it("complains on timechart about timeless points when overlaying", function() {
+        it('complains on timechart about timeless points when overlaying', function() {
             var timeChart = new TimeChartView({
                 juttleEnv: {
                     now: new Date()
@@ -86,11 +86,11 @@ describe('Table Sink View', function () {
 
             chart.consume([
                 {
-                    category: "A",
+                    category: 'A',
                     value: 1
                 },
                 {
-                    category: "B",
+                    category: 'B',
                     value: 1
                 }
             ]);

--- a/test/views/piechart.spec.js
+++ b/test/views/piechart.spec.js
@@ -173,17 +173,17 @@ describe('Pie Sink View', function () {
             });
         });
 
-        it("doesn't complain about timeless points", function() {
+        it('doesn\'t complain about timeless points', function() {
             var chart = new PieView({});
             chart.setDimensions(null, 200, 200);
 
             chart.consume([
                 {
-                    category: "A",
+                    category: 'A',
                     value: 1
                 },
                 {
-                    category: "B",
+                    category: 'B',
                     value: 1
                 }
             ]);

--- a/test/views/table.spec.js
+++ b/test/views/table.spec.js
@@ -115,17 +115,17 @@ describe('Table Sink View', function () {
             chart.runtimeMessages.getMessages().length.should.eql(1);
         });
 
-        it("doesn't complain about timeless points", function() {
+        it('doesn\'t complain about timeless points', function() {
             var chart = new TableView({});
             chart.setDimensions(null, 200, 200);
 
             chart.consume([
                 {
-                    category: "A",
+                    category: 'A',
                     value: 1
                 },
                 {
-                    category: "B",
+                    category: 'B',
                     value: 1
                 }
             ]);

--- a/test/views/text.spec.js
+++ b/test/views/text.spec.js
@@ -63,7 +63,7 @@ function verifyTextViewContents(textView, data, format) {
             });
             break;
         default:
-            throw "verifyTextViewContents only supports json and raw formats";
+            throw 'verifyTextViewContents only supports json and raw formats';
     }
 }
 
@@ -311,17 +311,17 @@ describe('TextView Sink View', function () {
             verifyTextViewContents(chart, [pt1,pt2], 'raw');
         });
 
-        it("doesn't complain about timeless points", function() {
+        it('doesn\'t complain about timeless points', function() {
             var chart = new TextView({});
             chart.setDimensions(null, 200, 200);
 
             chart.consume([
                 {
-                    category: "A",
+                    category: 'A',
                     value: 1
                 },
                 {
-                    category: "B",
+                    category: 'B',
                     value: 1
                 }
             ]);

--- a/test/views/tile.spec.js
+++ b/test/views/tile.spec.js
@@ -111,17 +111,17 @@ describe('Tile Sink View', function () {
             viewTestUtils.verifyNoRuntimeMessages(chart);
         });
 
-        it("doesn't complain about timeless points", function() {
+        it('doesn\'t complain about timeless points', function() {
             var chart = new TileView({});
             chart.setDimensions(null, 200, 200);
 
             chart.consume([
                 {
-                    category: "A",
+                    category: 'A',
                     value: 1
                 },
                 {
-                    category: "B",
+                    category: 'B',
                     value: 1
                 }
             ]);

--- a/test/views/timechart.spec.js
+++ b/test/views/timechart.spec.js
@@ -40,14 +40,14 @@ describe('Time Chart Sink View', function () {
                 });
 
                 chart.consume([
-                    { time : test_date, host : 'host1', pop : 'pop1', country : "Canada", value : 10 }
+                    { time : test_date, host : 'host1', pop : 'pop1', country : 'Canada', value : 10 }
                 ]);
 
                 chart.chart.series['0'].label.should.equal('country: Canada');
 
                 chart.consume([
-                    { time : test_date, host : 'host1', pop : 'pop2', country : "Canada", value : 10 },
-                    { time : test_date, host : 'host2', pop : 'pop2', country : "Canada", value : 10 }
+                    { time : test_date, host : 'host1', pop : 'pop2', country : 'Canada', value : 10 },
+                    { time : test_date, host : 'host2', pop : 'pop2', country : 'Canada', value : 10 }
                 ]);
 
                 chart.chart.series['0'].label.should.equal('host: host1, pop: pop1');
@@ -55,7 +55,7 @@ describe('Time Chart Sink View', function () {
                 chart.chart.series['2'].label.should.equal('host: host2, pop: pop2');
 
                 chart.consume([
-                    { time : test_date, host : 'host1', pop : 'pop2', country : "Portugal", value : 10 }
+                    { time : test_date, host : 'host1', pop : 'pop2', country : 'Portugal', value : 10 }
                 ]);
 
                 chart.chart.series['0'].label.should.equal('country: Canada, host: host1, pop: pop1');
@@ -87,8 +87,8 @@ describe('Time Chart Sink View', function () {
                 });
 
                 chart.consume([
-                    { time : test_date, value : 10, value2 : 20, host : "host1" },
-                    { time : test_date, value : 11, value2 : 30, host : "host2" }
+                    { time : test_date, value : 10, value2 : 20, host : 'host1' },
+                    { time : test_date, value : 11, value2 : 30, host : 'host2' }
                 ]);
 
                 chart.chart.series['0'].label.should.equal('host: host1');
@@ -103,8 +103,8 @@ describe('Time Chart Sink View', function () {
                 });
 
                 chart.consume([
-                    { time : test_date, value : 10, common: "test", not_common: "shown" },
-                    { time : test_date, value : 10, common: "test1" }
+                    { time : test_date, value : 10, common: 'test', not_common: 'shown' },
+                    { time : test_date, value : 10, common: 'test1' }
                 ]);
 
                 chart.chart.series['0'].label.should.equal('common: test, not_common: shown');
@@ -117,8 +117,8 @@ describe('Time Chart Sink View', function () {
                 });
 
                 chart.consume([
-                    { time : test_date, value : 10, common: "test", some_field: "shown" },
-                    { time : test_date, value : 10, common: "test"}
+                    { time : test_date, value : 10, common: 'test', some_field: 'shown' },
+                    { time : test_date, value : 10, common: 'test'}
                 ]);
 
                 chart.chart.series['0'].label.should.equal('some_field: shown');
@@ -274,7 +274,7 @@ describe('Time Chart Sink View', function () {
             viewTestUtils.verifyValidationError({
                 viewConstructor : TimeChartView,
                 params : {
-                    interval : "someString"
+                    interval : 'someString'
                 },
                 errorPath : 'interval',
                 error : {


### PR DESCRIPTION
because the eslintrc in test was redefining a bunch of things this lead
to the enforcement of single quotes being completely messed up. I
simply removed the duplicate information and let eslint do its thing
correctly by overlaying the `test/.eslintrc` configuration over the top
level `.eslintrc` and now things look correct.
