### PR TITLE
juttle-view: add static method getFlattenedParamValidationErrors

### DIFF
--- a/src/lib/strings/param-validation-error-strings.json
+++ b/src/lib/strings/param-validation-error-strings.json
@@ -1,0 +1,23 @@
+{
+    "UNKNOWN": "\"{{info.paramName}}\" is not a valid parameter.",
+    "REQUIRED": "\"{{info.paramName}}\" is missing.",
+    "INVALID_TYPE_OBJECT": "The value of \"{{info.paramName}}\" must be an object.",
+    "INVALID_TYPE_STRING": "The value of \"{{info.paramName}}\" must be a string.",
+    "INVALID_TYPE_NUMBER": "The value of \"{{info.paramName}}\" must be a number.",
+    "INVALID_TYPE_INTEGER": "The value of \"{{info.paramName}}\" must be a whole number.",
+    "INVALID_TYPE_BOOLEAN": "The value of \"{{info.paramName}}\" must be true or false.",
+    "OUT_OF_RANGE_GREATER_THAN": "The value of \"{{info.paramName}}\" must be greater than {{info.threshold}}.",
+    "OUT_OF_RANGE_LESS_THAN": "The value of \"{{info.paramName}}\" must be less than {{info.threshold}}.",
+    "OUT_OF_RANGE_GREATER_THAN_OR_EQUAL": "The value of \"{{info.paramName}}\" must be greater than or equal to {{info.threshold}}.",
+    "OUT_OF_RANGE_LESS_THAN_OR_EQUAL": "The value of \"{{info.paramName}}\" must be less than or equal to {{info.threshold}}.",
+    "ENUM": "The value of \"{{info.paramName}}\" must be one of {{info.allowedValues}}",
+    "INVALID_TYPE_ARRAY": "The value of \"{{info.paramName}}\" must be an array.",
+    "INVALID_TYPE_STRING_ARRAY": "The value of \"{{info.paramName}}\" must be an array of strings.",
+    "OVERLAY_SINK_NOT_FOUND": "You specified \"on\" but the id {{info.overlayId}} doesn't exist.",
+    "SERIES_SCALE_NOT_FOUND": "{{info.scale}} isn't a valid scale name; the only valid names are primary or secondary.",
+    "MISSING_KEY_FIELD_FOR_SERIES": "\"keyField\" is required when you're specifying a series.",
+    "MIN_VALUE_LESS_THAN_MAX_VALUE": "\"{{info.paramName}}\" must be less than \"maxValue\".",
+    "MAX_VALUE_GREATER_THAN_MIN_VALUE": "\"{{info.paramName}}\" must be greater than \"minValue\".",
+    "INVALID_SCALE": "{{info.scale}} isn't a valid scale name; the only valid names are primary or secondary.",
+    "DURATION_CANNOT_BE_NEGATIVE": "\"{{info.paramName}}\" must be a Duration or a non-negative number of seconds."
+}

--- a/src/views/juttle-view.js
+++ b/src/views/juttle-view.js
@@ -11,6 +11,10 @@ var BaseError = require('../lib/base-error');
 
 var SeriesFilter = require('../lib/generators/series-filter');
 
+var StringBundle  = require('../lib/strings/string-bundle');
+var paramValidationErrorStrings = require('../lib/strings/param-validation-error-strings');
+var paramValidationErrorStringBundle = new StringBundle(paramValidationErrorStrings);
+
 // the base view that other views extend.
 
 var JuttleView = Base.extend({
@@ -417,6 +421,26 @@ var JuttleView = Base.extend({
             findFlattenedOptions(optionValidationConfig, '');
 
             return validFlattenedOptions;
+        },
+
+        getFlattenedParamValidationErrors: function(errs) {
+            return _.mapObject(v.flattenErrors(errs), function(flattenedError, paramName) {
+                return flattenedError.map(function(singleError) {
+                    var info = _.extend({
+                        paramName: paramName
+                    }, singleError.info);
+
+                    var code = singleError.code;
+
+                    if (code === 'INVALID_TYPE' || code === 'OUT_OF_RANGE') {
+                        code += '_' + singleError.info.type;
+                    }
+
+                    return _.extend(singleError, {
+                        message: paramValidationErrorStringBundle.getStringForCode(code,{info: info})
+                    });
+                });
+            });
         }
     }
 );

--- a/test/views/juttle-view.spec.js
+++ b/test/views/juttle-view.spec.js
@@ -1,0 +1,82 @@
+require('chai').should();
+var JuttleView = require('../../src/views/juttle-view');
+var ObjectValidator = require('../../src/lib/object-validation');
+
+describe('juttle-view', function() {
+    describe('getFlattenedParamValidationErrors', function() {
+        it('top-level param', function() {
+            var obj = {
+                propertyB: 5
+            };
+
+            var errs = ObjectValidator.validate(obj, {
+                allowedProperties: ["propertyA"]
+            });
+
+            var flattenedErrors = JuttleView.getFlattenedParamValidationErrors(errs);
+
+            Object.keys(flattenedErrors).length.should.equal(1);
+
+            flattenedErrors.propertyB[0].message.should.equal('"propertyB" is not a valid parameter.');
+        });
+
+        it('nested param', function() {
+            var obj = {
+                nested: {
+                    propertyD: 2
+                }
+            };
+
+            var errs = ObjectValidator.validate(obj, {
+                allowedProperties: ["nested"],
+                properties: {
+                    nested: [
+                        {
+                            validator: ObjectValidator.validators.object,
+                            options: {
+                                allowedProperties: ["propertyA"]
+                            }
+                        }
+                    ]
+                }
+            });
+
+            var flattenedErrors = JuttleView.getFlattenedParamValidationErrors(errs);
+            flattenedErrors["nested.propertyD"][0].message.should.equal('"nested.propertyD" is not a valid parameter.');
+        });
+
+        it('multiple errors on one param', function() {
+
+            var obj = {
+                propertyB: 5
+            };
+
+            var errs = ObjectValidator.validate(obj, {
+                allowedProperties: ["propertyB"],
+                properties: {
+                    propertyB: [
+                        {
+                            validator: ObjectValidator.validators.greaterThan,
+                            options: {
+                                threshold: 10
+                            }
+                        },
+                        {
+                            validator: ObjectValidator.validators.greaterThan,
+                            options: {
+                                threshold: 20
+                            }
+                        }
+                    ]
+                }
+            });
+
+            var flattenedErrors = JuttleView.getFlattenedParamValidationErrors(errs);
+
+            var messageStrings = [flattenedErrors.propertyB[0].message, flattenedErrors.propertyB[1].message];
+
+            messageStrings.should.include('The value of "propertyB" must be greater than 10.');
+            messageStrings.should.include('The value of "propertyB" must be greater than 20.');
+        });
+    });
+});


### PR DESCRIPTION
Adding a static method called `getFlattenedParamValidationErrors` to `JuttleView`. The strings were pulled from the Jut 1.0 product.

Currently if invalid parameters are passed into a view constructor, it throws an error object describing the validations that failed. However, the error objects only contain codes and additional info but no human-friendly string that describes the validation error.

These human-friendly error messages are necessary so that juttle-viz consumers, namely outrigger via juttle-client-library, can display them to the end-user.

I am not 100% sure what layer these messages should be generated in.

@mnibecker 
