### PR TITLE
timechart series detection: don't add fields with null values to a series' keys

### DIFF
--- a/src/lib/series-detector.js
+++ b/src/lib/series-detector.js
@@ -1,3 +1,5 @@
+// Proof of Concept (untested and only used in prototype-views/visjs)
+
 /*
     Series Detector
      - Detects what series a given point belongs to and returns it.
@@ -47,7 +49,7 @@ var SeriesDetector = Base.extend({
         }
         else {
             _.each(point, function(val, name) {
-                if (!_.isNumber(val) && ! _.contains(this._fieldsToIgnore, name)) {
+                if (val === null && !_.isNumber(val) && ! _.contains(this._fieldsToIgnore, name)) {
                     keys[name] = val;
                 }
             }, this);

--- a/src/views/timechart.js
+++ b/src/views/timechart.js
@@ -635,7 +635,7 @@ var TimeChartView = JuttleView.extend({
         }
         else {
             _.each(point, function(val, name) {
-                if (!_.isNumber(val) && name !== this._attributes.timeField && name !== this._attributes.valueField) {
+                if (val !== null && !_.isNumber(val) && name !== this._attributes.timeField && name !== this._attributes.valueField) {
                     keys[name] = val;
                 }
             }, this);

--- a/test/views/timechart.spec.js
+++ b/test/views/timechart.spec.js
@@ -94,6 +94,28 @@ describe('Time Chart Sink View', function () {
                 chart.chart.series['0'].label.should.equal('host: host1');
                 chart.chart.series['1'].label.should.equal('host: host2');
             });
+
+            it('null fields should be ignored for determining series', function() {
+                var chart = new TimeChartView({
+                    juttleEnv : juttleEnv,
+                    params : {
+                        valueField : 'value'
+                    }
+                });
+
+                // The second two points should fall into the two series of the first two points
+                // despite having an extra field with a `null` value.
+                chart.consume([
+                    {time: test_date, name: 'metric1', host: 'A', value: 1},
+                    {time: test_date, name: 'metric2', host: 'A', value: 1},
+                    {time: new Date(test_date.getTime() + 1000), name: 'metric1', host: 'A', value: 2, numCores: null},
+                    {time: new Date(test_date.getTime() + 1000), name: 'metric2', host: 'A', value: 2, numCores: null}
+                ]);
+
+                chart.chart.series['0'].label.should.equal('name: metric1');
+                chart.chart.series['1'].label.should.equal('name: metric2');
+                Object.keys(chart.chart.series).length.should.equal(2);
+            });
         });
 
         describe('missing fields', function() {


### PR DESCRIPTION
Resolves #41

I looked into moving timechart to use `series-detector.js` as part of this (its currently only used in `prototype-views/timechart-visjs.js`) but it was a bit more complicated than I had hoped so leaving as is for now.

@mnibecker 
