### PR TITLE
changelog: update for 0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents all notable changes to juttle-viz. The release numbering uses [semantic versioning](http://semver.org).
 
+## 0.4.1
+
+Released 2016-02-08
+
+## Minor Changes
+
+- juttle-view: add static method getFlattenedParamValidationErrors [[#40](https://github.com/juttle/juttle-viz/pull/40)]
+
 ## 0.4.0
 
 Released 2016-02-05


### PR DESCRIPTION
I had merged https://github.com/juttle/juttle-viz/pull/40 into the `0.3.x` branch and released an `rc`, but forgot to merge that into the `master` branch. I did that in https://github.com/juttle/juttle-viz/pull/47, and now updating the changelog to reflect the change.

This is a new "feature" so we'd normally bump the minor version, but making an exception here as its a small, additive change and we were going to release it as a patch on `0.3.x`.

cc @mnibecker 
