### PR TITLE
juttle-view: remove drag icon

### DIFF
--- a/src/views/juttle-view.js
+++ b/src/views/juttle-view.js
@@ -253,29 +253,14 @@ var JuttleView = Base.extend({
     _setupHeader : function() {
         if (this._title) {
             var header = $('<div>').addClass('jut-chart-header');
-            var wrapper = $('<div>').addClass('jut-chart-drag-wrapper');
-            header.append(wrapper);
-
-            var drag_icon = this.dragIcon = $('<i>').addClass('fa fa-arrows chart-drag-icon jut-drag-handle');
-            drag_icon.hover(function () {
-                $(this).parent().addClass('hover');
-            }, function () {
-                $(this).parent().removeClass('hover');
-            });
-
-            drag_icon.on('dragstart', function(e) {
-                e.originalEvent.dataTransfer.setDragImage(this.parentElement, 0, 0);
-            });
-
-            wrapper.append(drag_icon);
 
             // add series filter container
             var series_filter = $('<div>').addClass('series-filter has-feedback');
-            wrapper.append(series_filter);
+            header.append(series_filter);
 
             this.title = $('<div>').addClass('jut-chart-title');
             this.title.html('&nbsp;');
-            wrapper.append(this.title);
+            header.append(this.title);
             $(this.el).append(header);
         }
     },

--- a/styles/_chart-main.scss
+++ b/styles/_chart-main.scss
@@ -485,38 +485,12 @@ div.jut-chart-header {
 }
 
 .jut-chart-header {
-    padding: 10px 15px 0px 15px;
-}
-
-.jut-chart-drag-wrapper {
-    padding: 0px 5px;
-    border: 1px solid transparent;
-
-    &.hover {
-        background-color: $gray-darker;
-    }
-
-    .chart-drag-icon {
-        font-size: 16px;
-        float: left;
-        position: relative;
-        color: $gray-background;
-        padding: 0;
-        padding-top: 3px;
-        margin-right: 6px;
-
-        &.hover {
-            background-color: $gray-darker;
-            color: $gray-icon;
-        }
-    }
+    padding: 10px 15px 0px 20px;
 
     .jut-chart-title {
-        margin-left: 11px;
         font-weight: 500;
         font-size: 18px;
     }
-
 }
 
 .series-filter {


### PR DESCRIPTION
Remove a drag icon that was left over from the Jut 1.0 product where we supported dragging charts around.

![image](https://cloud.githubusercontent.com/assets/3344137/13121920/47ef3c66-d569-11e5-93b2-a9f4605baff1.png)

@mnibecker 
