### PR TITLE
timechart: change 'display.dataDensity' param to be 'downsample' and make it a boolean

### DIFF
--- a/docs/charts/timechart.md
+++ b/docs/charts/timechart.md
@@ -24,9 +24,7 @@ view timechart -o {
   duration: duration,
   markerSize: n,
   overlayTime: boolean,
-  display: {
-   dataDensity: n
-  },
+  downsample: boolean,
   xScale: {
    label: 'string',
    tickFormat: 'd3FormatString'
@@ -65,7 +63,7 @@ view timechart -o {
 
 *or*
 ```
-view timechart -id 'string' -title 'string' -duration duration -display.dataDensity n -markerSize n -overlayTime boolean
+view timechart -id 'string' -title 'string' -duration duration -downsample boolean -markerSize n -overlayTime boolean
    -xScale.label 'string' -xScale.tickFormat 'd3FormatString'
   -yScales.primary.label 'string' -yScales.primary.tickFormat 'd3FormatString' -yScales.primary.minValue 'n' -yScales.primary.maxValue 'n' -yScales.primary.displayOnAxis 'left'
    -yScales.secondary.label 'string' -yScales.secondary.tickFormat 'd3FormatString' -yScales.secondary.minValue 'n' -yScales.secondary.maxValue 'n' -yScales.secondary.displayOnAxis 'left'
@@ -82,7 +80,7 @@ Parameter  |  Description  |  Required?
 `-id`  |  An identifier for this sink that serves as a handle for referencing the object in Juttle syntax; conceptually identical to a variable name  |  No
 `-title`  |  The title for the user-visible output, if it has one; the value may be any valid Juttle expression that produces a string  |  No; defaults to the name field that is present in all metrics points
 `-duration`  |  <p>The span of time to display, either in seconds (&gt;=10) or as a Juttle moment literal. <br><br>This feature can also be used for comparing data from multiple intervals, such as this week's Web traffic versus last week's. This is done by setting the -overlayTime flag to true.  |  No
-`-display.dataDensity`  |  The minimum number of pixels between points, for data downsampling  |  No; defaults to 5
+`-downsample`  | Whether the timechart should downsample data by averaging. Downsampling is triggered when the point density exceeds 1 point per 2 pixels.   |  No; defaults to true
 `-markerSize`  |  <p>he diameter of the circle representing each point, in pixels </p><p>When your data is not very dense, the chart renders distinctly separate circles connecting by a one-pixel line. For denser data, circles may be rendered close together, giving the appearance of a continuous line of the specified thickness.  </p>  |  No; defaults to 0 (circle not shown)
 `-overlayTime`  |  Whether the -duration value should be used to overlay time ranges. When true, the value of -duration drives the time-length of each overlayed range.  |  No; defaults to false
 `-xScale.label`  |  The string that labels the X scale  |  No; defaults to the value of the `time` field

--- a/src/lib/strings/runtime-message-strings.json
+++ b/src/lib/strings/runtime-message-strings.json
@@ -2,7 +2,7 @@
     "ALL_CATEGORIES_ARE_ZERO": "We can't draw this chart because all values are zero.",
     "WAITING_FOR_DATA": "waiting for data",
     "NO_DATA_RECEIVED": "The program finished and the chart received no data.",
-    "DOWNSAMPLING_WARNING": "There are too many points to fit on the chart so we are downsampling by averaging. You can control this with the \"-display.dataDensity\" parameter.",
+    "DOWNSAMPLING_WARNING": "There are too many points to fit on the chart so we are downsampling by averaging. You can control this with the \"-downsample\" parameter.",
     "TIME_FIELD_ERROR": "The \"timeField\" you specified does not contain valid values.",
     "COULD_NOT_DETERMINE_VALUE_FIELD": "We could not find a field to use for the \"valueField.\" Please specify one for the chart.",
     "COULD_NOT_DETERMINE_CATEGORY_FIELD": "We could not find a field to use for the \"categoryField.\" Please specify one for the chart.",

--- a/src/views/timechart.js
+++ b/src/views/timechart.js
@@ -50,6 +50,7 @@ var optionValidationConfig = {
     allowedProperties : [
         'id',
         'title',
+        'downsample',
         'col',
         'row',
         'display',
@@ -69,17 +70,7 @@ var optionValidationConfig = {
         duration : [v.validators.duration],
         overlayTime : [v.validators.boolean],
         markerSize : [v.validators.number],
-        display : [
-            {
-                validator : v.validators.object,
-                options : {
-                    allowedProperties : ['dataDensity'],
-                    properties : {
-                        dataDensity : [v.validators.number]
-                    }
-                }
-            }
-        ],
+        downsample : [v.validators.boolean],
         seriesLimit : [v.validators.number],
         xScales : [
             {
@@ -534,14 +525,11 @@ var TimeChartView = JuttleView.extend({
             timeField : 'time',
             seriesLimit : 20,
             markerSize : 0,
-            overlayTime : false
+            overlayTime : false,
+            downsample: true
         });
 
         options.display = options.display || {};
-
-        _.defaults(options.display, {
-            dataDensity : 5
-        });
 
         options.xScale = options.xScale || {};
 
@@ -584,6 +572,7 @@ var TimeChartView = JuttleView.extend({
             title : options.title,
             series : options.series,
             seriesLimit : options.seriesLimit,
+            downsample : options.downsample,
             keyField : options.keyField,
             valueField : options.valueField,
             timeField : options.timeField,
@@ -1174,7 +1163,9 @@ var TimeChartView = JuttleView.extend({
     // width and height, no monkey business.
     reallySetDimensions: function(width, height) {
         // XXX this should subtract the axis widths...
-        var limit = width / this._attributes.display.dataDensity;
+
+        var MIN_PIXELS_PER_POINT = 2;
+        var limit = this._attributes.downsample ? width / MIN_PIXELS_PER_POINT : Infinity;
         this.chart.set_downsample_limit(limit);
         _.each(this.dataTargets, function(target) {
             target.set_downsample_limit(limit);

--- a/test/views/timechart.spec.js
+++ b/test/views/timechart.spec.js
@@ -164,22 +164,6 @@ describe('Time Chart Sink View', function () {
             });
         });
 
-        it('unknown display field', function() {
-            viewTestUtils.verifyValidationError({
-                viewConstructor : TimeChartView,
-                params : {
-                    display : {
-                        columnOrder : 'asdf'
-                    }
-                },
-                errorPath : 'display.columnOrder',
-                error : {
-                    'code' : 'UNKNOWN',
-                    'info' : {}
-                }
-            });
-        });
-
         it('non-string valueField', function() {
             viewTestUtils.verifyValidationError({
                 viewConstructor : TimeChartView,
@@ -432,6 +416,51 @@ describe('Time Chart Sink View', function () {
             ]);
 
             viewTestUtils.verifyRuntimeMessage(chart, 'MULTIPLE_POINTS_SAME_TIME_SAME_SERIES');
+        });
+
+        it('downsampling defaults to 2 pixels per point', function() {
+            var chart = new TimeChartView({
+                juttleEnv : juttleEnv,
+                params : {}
+            });
+
+            chart.setDimensions(null, 800, 500);
+
+            var points = [];
+            for(var i = 0; i < 401; i++) {
+                points.push({
+                    time: new Date(i * 1000),
+                    value: 1
+                });
+            }
+
+            chart.consume(points.slice(0, 400));
+            viewTestUtils.verifyNoRuntimeMessages(chart);
+
+            chart.consume([points[points.length - 1]]);
+            viewTestUtils.verifyRuntimeMessage(chart, 'DOWNSAMPLING_WARNING');
+        });
+
+        it('downsampling can be turned off', function() {
+            var chart = new TimeChartView({
+                juttleEnv : juttleEnv,
+                params : {
+                    downsample: false
+                }
+            });
+
+            chart.setDimensions(null, 800, 500);
+
+            var points = [];
+            for(var i = 0; i < 500; i++) {
+                points.push({
+                    time: new Date(i * 1000),
+                    value: 1
+                });
+            }
+
+            chart.consume(points);
+            viewTestUtils.verifyNoRuntimeMessages(chart);
         });
 
         it('Show downsampling warning', function() {


### PR DESCRIPTION
Fixes https://github.com/juttle/juttle-viz/issues/6.

@mnibecker 
