### PR TITLE
text view: update options to match cli text view

### DIFF
--- a/docs/charts/text.md
+++ b/docs/charts/text.md
@@ -13,6 +13,7 @@ Display a raw dump of the output, in a fixed-width, console-style font, or as JS
 view text -o {
    id: 'string',
    title: 'string',
+   indent: n,
    height: n,
    limit: n,
    format: 'raw|json|csv'
@@ -23,6 +24,7 @@ view text -o {
 ```
 view text -id 'string' -title 'string'
   -height n
+  -indent n
   -limit n
   -format 'raw'
 ```
@@ -35,7 +37,8 @@ Parameter  |  Description  |  Required?
 `-title`  |  The title for the user-visible output, if it has one; the value may be any valid Juttle expression that produces a string  |  No; defaults to the name field that is present in all metrics points
 `-height`   The height of the log display in number of lines  |  No; default is 20 lines
 `-limit`  |  The total number of log lines to display  |  No; default is all log lines produced by the flowgraph
-`-format`  |  You can set this to 'csv' or 'json' to get CSV or pretty-printed JSON output, respectively. Batch delimiters are ignored when 'json' or 'csv' is specified. |  No; default is 'raw', which produces one data point per line, plus batch delimiters
+`-format`  |  You can set this to 'csv' or 'raw'. 'raw' will print each individual point as JSON and show batch delimiters. |  No; default is 'json'.
+`-indent`  | When `-format` is 'json', specifies how many spaces to use for indentation for pretty-printing the JSON.
 
 _Example: raw display style_
 

--- a/src/views/text.js
+++ b/src/views/text.js
@@ -4,7 +4,6 @@ var JuttleView = require('./juttle-view');
 var tabularDataUtils = require('../lib/utils/tabular-data-utils');
 var Backbone = require('backbone');
 
-var JSON_INDENT = 4;
 var v = require('../lib/object-validation');
 
 var TextComponent = function(element, options) {
@@ -131,7 +130,20 @@ TextComponent.prototype._formatAsRaw = function(data) {
 };
 
 TextComponent.prototype._formatAsJSON = function(data) {
-    return JSON.stringify(data, null, JSON_INDENT);
+    if (this.options.indent !== 0) {
+        return JSON.stringify(data, null, this.options.indent);
+    }
+    else {
+        var points = data.map(function(item) {
+            return JSON.stringify(item);
+        }).join(',\n');
+
+        if (points !== '') {
+            points = points + '\n';
+        }
+
+        return '[\n' + points + ']';
+    }
 };
 
 TextComponent.prototype._formatAsCSV = function(data, columnOrder) {
@@ -163,6 +175,7 @@ var optionValidationConfig = {
         'row',
         'height',
         'limit',
+        'indent',
         'format',
         'times',
         'ticks',
@@ -188,6 +201,7 @@ var optionValidationConfig = {
                 }
             }
         ],
+        indent : [ v.validators.integer ],
         format : [
             {
                 validator : v.validators.enum,
@@ -236,7 +250,8 @@ var TextView = JuttleView.extend({
             title: '',
             height : 20,
             limit : 1000,
-            format : 'raw',
+            indent : 0,
+            format : 'json',
             times : false,
             ticks : false,
             marks : true

--- a/test/views/text.spec.js
+++ b/test/views/text.spec.js
@@ -53,7 +53,6 @@ function verifyTextViewContents(textView, data, format) {
 
     switch(format) {
         case 'json':
-            textAreaValue.should.equal(JSON.stringify(data,null,4));
             compareJSONtoJS(textAreaValue,data);
             break;
         case 'raw':
@@ -72,7 +71,11 @@ describe('TextView Sink View', function () {
 
     describe('format', function() {
         it('raw', function() {
-            var textView = new TextView({});
+            var textView = new TextView({
+                params: {
+                    format: 'raw'
+                }
+            });
 
             textView.consume([POINT_1_FIELD]);
             verifyTextViewContents(textView, [POINT_1_FIELD], 'raw');
@@ -143,6 +146,7 @@ describe('TextView Sink View', function () {
             it('times: true', function() {
                 var textView = new TextView({
                     params : {
+                        format : 'raw',
                         marks : true,
                         times : true
                     }
@@ -158,6 +162,7 @@ describe('TextView Sink View', function () {
             it('times: false', function() {
                 var textView = new TextView({
                     params : {
+                        format : 'raw',
                         marks : true,
                         times : false
                     }
@@ -174,6 +179,7 @@ describe('TextView Sink View', function () {
         it('false', function() {
             var textView = new TextView({
                 params : {
+                    format : 'raw',
                     marks : false
                 }
             });
@@ -185,11 +191,38 @@ describe('TextView Sink View', function () {
         });
     });
 
+    describe('indent', function() {
+        it('defaults to 0', function() {
+            var textView = new TextView({});
+
+            textView.consume([POINT_1_FIELD, POINT_1_FIELD]);
+
+            var textArea = $(textView.visuals['0']).find('textarea');
+
+            textArea.val().should.equal('[\n{"a":"AAA"},\n{"a":"AAA"}\n]');
+        });
+
+        it('can be configured', function() {
+            var textView = new TextView({
+                params: {
+                    indent: 3
+                }
+            });
+
+            textView.consume([POINT_1_FIELD, POINT_1_FIELD]);
+
+            var textArea = $(textView.visuals['0']).find('textarea');
+
+            textArea.val().should.equal('[\n   {\n      "a": "AAA"\n   },\n   {\n      "a": "AAA"\n   }\n]');
+        });
+    });
+
     describe('ticks', function() {
         describe('true', function() {
             it('times: true', function() {
                 var textView = new TextView({
                     params : {
+                        format : 'raw',
                         ticks : true,
                         times : true
                     }
@@ -205,6 +238,7 @@ describe('TextView Sink View', function () {
             it('times: false', function() {
                 var textView = new TextView({
                     params : {
+                        format : 'raw',
                         ticks : true,
                         times : false
                     }
@@ -221,6 +255,7 @@ describe('TextView Sink View', function () {
         it('false', function() {
             var textView = new TextView({
                 params : {
+                    format : 'raw',
                     ticks : false
                 }
             });
@@ -285,12 +320,13 @@ describe('TextView Sink View', function () {
             var chart = new TextView({});
 
             chart.consume_eof();
-            chart.runtimeMessages.getMessages().length.should.eql(0);
+            chart.runtimeMessages.getMessages().length.should.eql(1);
         });
 
         it('Too many items', function() {
             var chart = new TextView({
                 params : {
+                    format : 'raw',
                     limit : 2
                 }
             });


### PR DESCRIPTION
- Default format to 'json' instead of 'raw'
- Support a -indent option and default to 0

Fixes https://github.com/juttle/juttle-viz/issues/5.

@mnibecker 
