### PR TITLE
table view: allow progressive option

### DIFF
--- a/src/views/table.js
+++ b/src/views/table.js
@@ -14,7 +14,10 @@ var optionValidationConfig = {
         'markdownFields',
         'limit',
         'update',
-        'height'
+        'height',
+        // Not used in this view but used in the CLI table.
+        // Add here so juttle written for the CLI can be run in the browser.
+        'progressive'
     ],
     properties : {
         limit : [


### PR DESCRIPTION
Adding as an allowed option so that juttles written for the juttle CLI, where the table does have a progressive option, work here as well.

This table view doesn't actually do anything with the option's value.

@demmer @mnibecker
