### PR TITLE
juttle-view#consume_mark: instead of time value, expect object with time property

### DIFF
--- a/src/views/juttle-view.js
+++ b/src/views/juttle-view.js
@@ -79,10 +79,6 @@ var JuttleView = Base.extend({
 
     _consume_mark: function(time) {}, //to be overridden as part of the consume_mark template pattern defined below
     consume_mark: function(time) {
-        if (_.isString(time)) {
-            time = new Date(time);
-        }
-
         if (this._paused) {
             this.pauseQueue.push(this.consume_mark.bind(this, time));
             return;

--- a/src/views/juttle-view.js
+++ b/src/views/juttle-view.js
@@ -72,9 +72,7 @@ var JuttleView = Base.extend({
 
         this._validateTimeFieldsInBatch(batch);
 
-        if (_.isFunction(this._consume)) {
-            this._consume(batch);
-        }
+        this._consume(batch);
     },
 
     _consume_mark: function(mark) {}, //to be overridden as part of the consume_mark template pattern defined below
@@ -84,9 +82,7 @@ var JuttleView = Base.extend({
             return;
         }
 
-        if (_.isFunction(this._consume_mark)) {
-            this._consume_mark(mark);
-        }
+        this._consume_mark(mark);
     },
 
     _consume_eof: function() {}, //to be overridden as part of the consume_eof template pattern defined below
@@ -96,9 +92,7 @@ var JuttleView = Base.extend({
             return;
         }
 
-        if (_.isFunction(this._consume_eof)) {
-            this._consume_eof();
-        }
+        this._consume_eof();
 
         if (!this._hasReceivedData) {
             this.runtimeMessages.remove(commonRuntimeMessages.WAITING_FOR_DATA);
@@ -117,9 +111,7 @@ var JuttleView = Base.extend({
             return;
         }
 
-        if (_.isFunction(this._consume_tick)) {
-            this._consume_tick(time);
-        }
+        this._consume_tick(time);
     },
 
     pause : function() {

--- a/src/views/juttle-view.js
+++ b/src/views/juttle-view.js
@@ -77,15 +77,15 @@ var JuttleView = Base.extend({
         }
     },
 
-    _consume_mark: function(time) {}, //to be overridden as part of the consume_mark template pattern defined below
-    consume_mark: function(time) {
+    _consume_mark: function(mark) {}, //to be overridden as part of the consume_mark template pattern defined below
+    consume_mark: function(mark) {
         if (this._paused) {
-            this.pauseQueue.push(this.consume_mark.bind(this, time));
+            this.pauseQueue.push(this.consume_mark.bind(this, mark));
             return;
         }
 
         if (_.isFunction(this._consume_mark)) {
-            this._consume_mark(time);
+            this._consume_mark(mark);
         }
     },
 

--- a/src/views/text.js
+++ b/src/views/text.js
@@ -35,13 +35,13 @@ var TextComponent = function(element, options) {
             }
             self.dataTarget.push([text]);
         },
-        batch_end: function(time) {
+        batch_end: function(mark) {
             if (!options.marks || options.format !== 'raw') {
                 return ;
             }
             var text = '--------------------------------------------------------------';
             if (options.times) {
-                text += time.toISOString();
+                text += mark.time.toISOString();
             }
             self.dataTarget.push([text]);
         },
@@ -274,8 +274,8 @@ var TextView = JuttleView.extend({
     },
 
     // gets called when a batch finishes
-    _consume_mark: function(time) {
-        this.textComponent.dataTarget.batch_end(time);
+    _consume_mark: function(mark) {
+        this.textComponent.dataTarget.batch_end(mark);
     },
 
     // gets called for ticks

--- a/test/views/text.spec.js
+++ b/test/views/text.spec.js
@@ -155,7 +155,7 @@ describe('TextView Sink View', function () {
                 var textArea = $(textView.visuals['0']).find('textarea');
 
                 var time = new Date();
-                textView.consume_mark(time);
+                textView.consume_mark({ time: time });
                 textArea.val().should.equal(MARK + time.toISOString());
             });
 


### PR DESCRIPTION
Fixes https://github.com/juttle/juttle-viz/issues/74.

@davidvgalbraith @VladVega
